### PR TITLE
docs(contributing): improve installation process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,36 @@
 # My infra
-## Mobile application for OVH created with Ionic2/angular2
 
-### Installation
-+ Pay attention !!!! Use node version >= 6.0 and use the latest release of ionic cli (```npm install -g ionic``` even if you already have the ionic v2 cli installed)
-```
-$ npm install -g ionic@beta typings typescript commitizen
+> Mobile application for OVH created with [Ionic 2](http://ionicframework.com/docs/v2/) & [Angular 2](https://angular.io/).
+
+## Installation
+
+:warning: Use Node.js version `>=6.0` and use the latest release of Ionic CLI (```npm install -g ionic``` even if you already have the Ionic v2 CLI installed).
+
+```bash
 $ git clone https://github.com/bnjjj/my-infra.git
 $ cd my-infra
-$ npm i
-$ typings install
-$ ionic state restore
+$ npm install
 ```
 
-### Run
+## Run
+
+```bash
+$ npm run start # or you can use `ionic serve --lab`
 ```
-$ ionic serve --lab
+
+### Troubleshooting
+
+We recommand you to install the [Allow-Control-Allow-Oirigin:*](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi?utm_source=chrome-ntp-icon) extension.
+
+This extension helps you to prevent this following error that you might notice into your console while you are trying to logged in:
+
+```js
+No 'Access-Control-Allow-Origin' header is present on the requested resource…
 ```
 
 ### Ionic cli
-If you're not used to use Ionic, go on the [Ionic Documentation](http://ionicframework.com/docs/v2/)
+
+If you're not used to use Ionic, go on the [Ionic Documentation](http://ionicframework.com/docs/v2/).
 
 ### Creating an Issue
 
@@ -27,7 +39,6 @@ If you have a question about using the framework, please ask me on my [twitter](
 If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported](https://github.com/bnjjj/my-infra/issues?utf8=%E2%9C%93&q=is%3Aissue). You can search through existing issues to see if there is a similar one reported. Include closed issues as it may have been closed with a solution.
 
 Next, [create a new issue](https://github.com/bnjjj/my-infra/issues/new) that thoroughly explains the problem. Please fill out the populated issue form before submitting the issue.
-
 
 ### Creating a Pull Request
 
@@ -40,13 +51,15 @@ Looking for an issue to fix? Make sure to look through our issues with the [help
 1. Fork the repo.
 2. Clone your fork.
 3. Make a branch for your change.
-4. Run `npm install` (make sure you have [node](https://nodejs.org/en/) and [npm](http://blog.npmjs.org/post/85484771375/how-to-install-npm) installed first)
+4. Run `npm install` (make sure you have [Node.js](https://nodejs.org/en/) and [npm](http://blog.npmjs.org/post/85484771375/how-to-install-npm) installed first).
 
 ### Commiting
-1. Install Commitizen (add sudo if on OSX/Linux): npm install -g commitizen
-2. Use commitizen to commit instead of git commit: git cz or git-cz
+
+1. Install Commitizen (add sudo if on OSX/Linux): `npm install -g commitizen`.
+2. Use commitizen to commit instead of git commit: `git cz` or `git-cz`.
 3. This will prompt you with questions and commit when you are finished.
 4. Submit the Pull Request!
 
 ### License
+
 By contributing your code to the bnjjj/my-infra GitHub Repository, you agree to license your contribution under the MIT license.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   "name": "my-infra",
   "description": "My infra: a mobile application to manage some of the OVH products and services.",
   "scripts": {
-    "postinstall": "gulp build",
+    "preinstall": "npm install -g ionic typings typescript commitizen",
+    "postinstall": "ionic state restore && typings install && gulp build",
+    "start": "ionic serve --lab",
     "android-release": "cd platforms/android/build/outputs/apk && rm -f my-infra.apk && ionic build android --release && jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore my-release-key.keystore android-release-unsigned.apk my-infra && ~/Library/Android/sdk/build-tools/23.0.3/zipalign -v 4 android-release-unsigned.apk my-infra.apk"
   },
   "cordovaPlugins": [


### PR DESCRIPTION
Just run `npm install` and you ready to start the App.

Under the hood `preinstall` and `postinstall` are used to manage required modules.