### PR TITLE
[webHosting] Delete some informations

### DIFF
--- a/app/pages/products/hosting-web/hosting-web.html
+++ b/app/pages/products/hosting-web/hosting-web.html
@@ -67,14 +67,6 @@
             <span [innerText]="server.filer"></span>
           </ion-note>
         </ion-item>
-        <ion-item>
-          <ion-label>
-            Système d'exploitation
-          </ion-label>
-          <ion-note item-right>
-            <span class="capitalize" [innerText]="server.operatingSystem"></span>
-          </ion-note>
-        </ion-item>
       </ion-item-group>
       <ion-item-group>
         <title-separation (collapse)="hideNetwork = !$event">


### PR DESCRIPTION
I delete "filer" field because the filer information is not usefull without link from travaux.ovh.net. I think the monitoring show more informations
I delete "OS" because now, you can only have linux as operating system. Windows offers have been deleted some months ago.